### PR TITLE
Show 'Imperial (RYJ)' in 'scheme' column (for now)

### DIFF
--- a/R/azure.R
+++ b/R/azure.R
@@ -65,7 +65,7 @@ get_report_sites <- function(container_support) {
 
 }
 
-get_scheme_lookup <- function(container_support, file) {
+get_scheme_lookup <- function(container_support) {
   AzureStor::storage_read_csv(
     container_support,
     "nhp-scheme-lookup.csv",
@@ -75,7 +75,11 @@ get_scheme_lookup <- function(container_support, file) {
       code = `Trust ODS Code`,
       scheme = `Name of Hospital site`,
       trust = `Name of Trust`
-    )
+    ) |>
+    # Reduce St Marys, Charing Cross, Hammersmith (all RYJ) to Imperial
+    dplyr::mutate(scheme = dplyr::if_else(code == "RYJ", "Imperial", scheme)) |>
+    dplyr::distinct(code, scheme, trust) |>
+    dplyr::arrange(code)
 }
 
 get_nhp_user_allowed_datasets <- function(groups = NULL, container_support) {


### PR DESCRIPTION
Close #22.

The scheme lookup had three rows like this:

| code | scheme | trust |
| :---- | :---- | :---- |
| RYJ| Charing Cross| Imperial College Healthcare NHS Trust |
| RYJ | Hammersmith | Imperial College Healthcare NHS Trust |
| RYJ | St Marys | Imperial College Healthcare NHS Trust |

This PR changes these rows to:

| code | scheme | trust |
| :---- | :---- | :---- |
| RYJ| Imperial | Imperial College Healthcare NHS Trust |

The 'scheme' column in [the tagged-runs table](https://connect.strategyunitwm.nhs.uk/nhp/tagged_runs/nhp-tagged-runs.html) will then say 'Imperial (RYJ)' rather than 'Charing Cross (RYJ)'. The latter is erroneous; it's a bug in the matching process because there's three things to match to.

This is okay for now, but I acknowledge that this approach may need to change in future if the system for managing the three Imperial sites changes (they may need reinstating and the matching convention might need to be updated).